### PR TITLE
Shuffle array before starting

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,6 +461,12 @@
             cell.innerHTML = display;
         }
 
+        // Shuffle array order before starting
+        for (let i = urls.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [urls[i], urls[j]] = [urls[j], urls[i]];
+        }
+
         // Create div for each target
        for (var i=0; i<urls.length; i++) {
             var newHTML = '<div class="col-lg-3 col-md-4 col-sm-6" id="target' + i.toString() + '"></div>';
@@ -472,7 +478,6 @@
         for (var i=0; i<urls.length; i++) {
             flood(urls[i], i);
         }
-
     </script>
 </body>
 


### PR DESCRIPTION
I noticed the first element was making a lot more requests than the others. Is this just result of a faster server? In any event, might be nice to shuffle the order anyway.