### PR TITLE
Balance the flood

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,6 +399,10 @@
             });
         }
 
+        async function sleep(ms) {
+            return new Promise(r => setTimeout(r, ms));
+        }         
+
         async function flood(n) {
             const url = urls[n];
             const target = targets[url];
@@ -425,6 +429,8 @@
                         })
                         .finally(() => updateTargetDisplay(n))
                 );
+
+                await sleep(1);
             }
         }
 


### PR DESCRIPTION
Adds a minimal (1ms) delay between the while loop iterations. It shouldn't affect the overall performance but the `await` makes sure the first loop doesn't fill up the queue before any other loops get started.

Fixes #59 